### PR TITLE
Fixed regex for profile url to include profile.php?id=... formats

### DIFF
--- a/src/Module/MemberRequestModule/MemberRequestModule.php
+++ b/src/Module/MemberRequestModule/MemberRequestModule.php
@@ -119,7 +119,7 @@ class MemberRequestModule extends ModuleAbstract
      * @return string The fully qualified context-free profile URL.
      */
     private function sanitizeProfileUrl($url) {
-        preg_match("%^(https?\://m\.facebook\.com|)/?([^/]+)\?%", $url, $match);
+        preg_match("%^(https?\://.*\.facebook\.com|)/?(profile.php\?id=[0-9]+|[^/\?]+)%", $url, $match);
 
         $facebookId = $match[2];
 


### PR DESCRIPTION
This is a bug fix for the profile URLs that are parsed during membership approval.
# Change log
- The profile URL now correctly parses URLs with the _profile.php?id=..._ format. Previously only _named_ URLs were taken into account.
